### PR TITLE
Add .podspec

### DIFF
--- a/ParseKit.podspec
+++ b/ParseKit.podspec
@@ -1,0 +1,35 @@
+Pod::Spec.new do |s|
+  s.name     = 'ParseKit'
+  s.version  = '0.7'
+  s.license  = 'Apache'
+  s.summary  = 'Objective-C/Cocoa String Tokenizer and Parser toolkit. Supports Grammars.'
+  s.homepage = 'http://parsekit.com/'
+  s.author   = { 'Todd Ditchendorf' => 'todd.ditchendorf@gmail.com' }
+
+  s.source   = { :git => 'https://github.com/itod/parsekit.git', :tag => '0.7'}
+
+  s.description = %{
+    ParseKit is a Mac OS X Framework written by Todd Ditchendorf in
+    Objective-C 2.0 and released under the Apache Open Source License
+    Version 2.0. ParseKit is suitable for use on Mac OS X Leopard,
+    Snow Leopard or iOS. ParseKit is an Objective-C implementation
+    of the tools described in Building Parsers with Java by Steven
+    John Metsker.
+
+    ParseKit includes additional features beyond the
+    designs from the book and also some changes to match common
+    Cocoa/Objective-C conventions. These changes are relatively superficial,
+    however, and Metsker’s book is the best documentation available
+    for ParseKit.
+  }
+
+  s.source_files           =  'include/**/*.{h,m}', 'src/**/*.{h,m}', 'lib/MGTemplateEngine/MGTemplate*.{h,m}', 
+                              'lib/MGTemplateEngine/ICUTemplateMatcher.{h,m}', 
+                              'lib/MGTemplateEngine/*DeepMutableCopy.{h,m}'
+  s.ios.prefix_header_file =  'src/ParseKitMobile_Prefix.pch'
+  s.osx.prefix_header_file =  'src/ParseKit_Prefix.pch'
+  s.ios.frameworks         =  'Foundation'
+  s.osx.framework          =  'Foundation'
+  s.library                =  'icucore'
+  s.requires_arc           =  false
+end


### PR DESCRIPTION
There's a .podspec for ParseKit on CocoaPods, but it's not included in the official repo and that makes it a bit troublesome to try and fix some outstanding issues in the kit along with a CocoaPods-enabled app. Adding the .podspec file to the root of the repo solves the problem, so that you can always say in your Podfile:

pod 'ParseKit', path: '/some/path/on/your/local/filesystem/where/the/repo/is/checked/out'

Yours fork seems to be the most maintained on GitHub currently so I've decided to fork it and add some essential patches. ;)
